### PR TITLE
fix: payload error, pagination in user-albums

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16,11 +16,11 @@ import { cleanupInactiveDocuments } from "./lib/cleanup.js";
 dotenv.config();
 const app = express();
 
-app.use(express.json()); 
-app.use(cookieParser());
-
 app.use(express.json({limit: '50mb'}));
 app.use(express.urlencoded({limit: '50mb', extended: true}));
+
+app.use(express.json()); 
+app.use(cookieParser());
 
 
 const corsOptions = {

--- a/frontend/src/pages/UserAlbums.jsx
+++ b/frontend/src/pages/UserAlbums.jsx
@@ -22,12 +22,12 @@ const UserAlbums = () => {
       console.log('Albums response:', response.data);
       
       // Make sure we're setting all album data including listened ones
-      setAlbums(response.data.albums.map(album => ({
-        ...album,
-        images: album.images || [],
-        artists: album.artists || []
-      })));
-      
+      // setAlbums(response.data.albums.map(album => ({
+      //   ...album,
+      //   images: album.images || [],
+      //   artists: album.artists || []
+      // })));
+      setAlbums(response.data.albums);
       setCurrentPage(response.data.currentPage);
       setTotalPages(response.data.totalPages);
     } catch (err) {


### PR DESCRIPTION
The total count was incorrectly using the max of ratings and listened counts, which doesn't account for overlap. 
>> so i first fetched all albums (ratings, listened, and likes), combined and deduplicated them while preserving timestamps and ratings, applied pagination only to the sorted listed of response


~also wanted to push this on main, but didn't care to double check so here we are